### PR TITLE
enhance: mejorar pre-commit hook para forzar documentación en CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@
 
 ### 🔧 Technical
 
+- **Improved Pre-commit Hook**: Enhanced CHANGELOG enforcement for better documentation
+  - Add strict verification that staged files are documented in CHANGELOG
+  - Block commits when significant files are staged without CHANGELOG updates
+  - Show staged files that require documentation
+  - Provide clear guidance on how to update CHANGELOG
+
 ### 📱 Mobile Features
 
 ### 🖥️ Desktop Features

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -1,41 +1,96 @@
 #!/bin/sh
 
-# Pre-commit hook to verify CHANGELOG
-# Verifies that if there are significant changes, the CHANGELOG is updated
+# Pre-commit hook to verify CHANGELOG for Capital Caos Frontend
+# Blocks commits if CHANGELOG is not updated when there are significant changes
 
 CHANGELOG_FILE="CHANGELOG.md"
 UNRELEASED_SECTION="## [Unreleased]"
 
-# Verificar si hay cambios en archivos de código (excluyendo documentación)
-CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx|css|scss)$')
+# Get staged files (excluding CHANGELOG.md itself and certain file types)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -v "$CHANGELOG_FILE" | grep -E '\.(js|jsx|ts|tsx|css|scss|json)$' | grep -v "^docs/" | grep -v "^public/")
 
-if [ -n "$CHANGED_FILES" ]; then
-    echo "🔍 Verifying CHANGELOG..."
-    
-    # Verify that CHANGELOG exists
-    if [ ! -f "$CHANGELOG_FILE" ]; then
-        echo "❌ CHANGELOG.md not found"
-        echo "Please create a CHANGELOG.md with the [Unreleased] section"
-        exit 1
-    fi
-    
-    # Verify that [Unreleased] section exists
-    if ! grep -q "$UNRELEASED_SECTION" "$CHANGELOG_FILE"; then
-        echo "❌ [Unreleased] section not found in CHANGELOG.md"
-        echo "Please add the [Unreleased] section to the CHANGELOG"
-        exit 1
-    fi
-    
-    # Verify that there is at least one entry in [Unreleased]
-    UNRELEASED_CONTENT=$(sed -n '/## \[Unreleased\]/,/^## /p' "$CHANGELOG_FILE" | grep -E '^\s*[-*]\s*\*\*')
-    
-    if [ -z "$UNRELEASED_CONTENT" ]; then
-        echo "⚠️  Warning: No entries found in [Unreleased] section"
-        echo "Consider adding entries to the CHANGELOG to document changes"
-        echo "You can use: node scripts/update-changelog.js [type] [description]"
-    else
-        echo "✅ CHANGELOG verified successfully"
-    fi
+# If no significant files are staged, allow commit
+if [ -z "$STAGED_FILES" ]; then
+    echo "✅ No significant files staged, allowing commit"
+    exit 0
 fi
+
+# Check if CHANGELOG.md exists
+if [ ! -f "$CHANGELOG_FILE" ]; then
+    echo "❌ CHANGELOG.md not found"
+    echo "Please create a CHANGELOG.md with the [Unreleased] section"
+    exit 1
+fi
+
+# Check if [Unreleased] section exists
+if ! grep -q "## \[Unreleased\]" "$CHANGELOG_FILE"; then
+    echo "❌ [Unreleased] section not found in CHANGELOG.md"
+    echo "Please add the [Unreleased] section to the CHANGELOG"
+    exit 1
+fi
+
+# Check if there are any entries in [Unreleased] section
+UNRELEASED_CONTENT=$(sed -n '/## \[Unreleased\]/,/^## /p' "$CHANGELOG_FILE" | grep -E '^\s*[-*]\s*\*\*')
+
+if [ -z "$UNRELEASED_CONTENT" ]; then
+    echo "❌ No entries found in [Unreleased] section"
+    echo "You must add entries to the CHANGELOG before committing"
+    echo ""
+    echo "Staged files that require documentation:"
+    echo "$STAGED_FILES" | sed 's/^/  - /'
+    echo ""
+    echo "Use: node scripts/update-changelog.js <type> <description>"
+    echo ""
+    echo "Available types: added, fixed, enhanced, technical, security, performance, deployment, ui, ux, api"
+    echo "Example: node scripts/update-changelog.js fixed \"Chart rendering issue\""
+    echo ""
+    echo "Commit blocked. Please update CHANGELOG and try again."
+    exit 1
+fi
+
+# Check if CHANGELOG has been modified in this commit
+CHANGELOG_MODIFIED=$(git diff --cached --name-only | grep "$CHANGELOG_FILE")
+
+if [ -z "$CHANGELOG_MODIFIED" ]; then
+    echo "❌ CHANGELOG.md not updated but significant files are staged"
+    echo ""
+    echo "Staged files that require documentation:"
+    echo "$STAGED_FILES" | sed 's/^/  - /'
+    echo ""
+    echo "You must update the CHANGELOG to document these changes"
+    echo ""
+    echo "Use: node scripts/update-changelog.js <type> <description>"
+    echo ""
+    echo "Available types: added, fixed, enhanced, technical, security, performance, deployment, ui, ux, api"
+    echo "Example: node scripts/update-changelog.js fixed \"Chart rendering issue\""
+    echo ""
+    echo "Commit blocked. Please update CHANGELOG and try again."
+    exit 1
+fi
+
+# Verify that the CHANGELOG changes are meaningful (not just whitespace)
+CHANGELOG_CHANGES=$(git diff --cached "$CHANGELOG_FILE" | grep -E '^\s*[-*]\s*\*\*' | wc -l)
+
+if [ "$CHANGELOG_CHANGES" -eq 0 ]; then
+    echo "❌ CHANGELOG.md was modified but no meaningful entries were added"
+    echo ""
+    echo "Staged files that require documentation:"
+    echo "$STAGED_FILES" | sed 's/^/  - /'
+    echo ""
+    echo "You must add meaningful entries to the CHANGELOG"
+    echo ""
+    echo "Use: node scripts/update-changelog.js <type> <description>"
+    echo ""
+    echo "Available types: added, fixed, enhanced, technical, security, performance, deployment, ui, ux, api"
+    echo "Example: node scripts/update-changelog.js fixed \"Chart rendering issue\""
+    echo ""
+    echo "Commit blocked. Please add meaningful CHANGELOG entries and try again."
+    exit 1
+fi
+
+echo "✅ CHANGELOG verified successfully"
+echo "📝 Changes documented in CHANGELOG.md"
+echo "📁 Staged files:"
+echo "$STAGED_FILES" | sed 's/^/  - /'
 
 exit 0 


### PR DESCRIPTION
- Agregar verificación estricta de que archivos staged estén documentados
- Bloquear commits cuando hay archivos significativos sin actualizar CHANGELOG
- Mostrar archivos staged que requieren documentación
- Proporcionar guía clara sobre cómo actualizar CHANGELOG