### PR TITLE
fix: corregir timezone en EquityChart y DrawdownChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ✨ Added
 
 ### 🐛 Fixed
+- **corregir timezone en EquityChart y DrawdownChart**
 
 ### 🎨 Enhanced
 

--- a/src/components/DrawdownChart.jsx
+++ b/src/components/DrawdownChart.jsx
@@ -33,17 +33,17 @@ function buildDrawdownData(operations) {
     });
 }
 
-function formatDateLuxon(date) {
+function formatDateLuxon(date, timeZone = "UTC") {
   if (!date) return "-";
   let dt = DateTime.fromISO(date, { zone: "utc" });
   if (!dt.isValid) {
     dt = DateTime.fromFormat(date, "yyyy-MM-dd HH:mm:ss", { zone: "utc" });
   }
   if (!dt.isValid) return date;
-  return dt.toFormat("dd/MM/yy - h:mm:ss a");
+  return dt.setZone(timeZone).toFormat("dd/MM/yy - h:mm:ss a");
 }
 
-export default function DrawdownChart({ operations }) {
+export default function DrawdownChart({ operations, timeZone = "UTC" }) {
   const data = buildDrawdownData(operations);
   if (!data.length) {
     return <Typography>No closed trades to display drawdown.</Typography>;
@@ -62,7 +62,7 @@ export default function DrawdownChart({ operations }) {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="date"
-              tickFormatter={formatDateLuxon}
+              tickFormatter={(date) => formatDateLuxon(date, timeZone)}
               minTickGap={20}
             />
             <YAxis domain={["auto", 0]} />
@@ -71,7 +71,7 @@ export default function DrawdownChart({ operations }) {
                 value,
                 name === "drawdown" ? "Drawdown (%)" : "Equity",
               ]}
-              labelFormatter={(d) => `Date: ${formatDateLuxon(d)}`}
+              labelFormatter={(d) => `Date: ${formatDateLuxon(d, timeZone)}`}
               cursor={false}
             />
             <Line

--- a/src/components/charts/EquityChart.jsx
+++ b/src/components/charts/EquityChart.jsx
@@ -47,14 +47,14 @@ function buildEquityDrawdownData(operations) {
     });
 }
 
-function formatDateLuxon(date) {
+function formatDateLuxon(date, timeZone = "UTC") {
   if (!date) return "-";
   let dt = DateTime.fromISO(date, { zone: "utc" });
   if (!dt.isValid) {
     dt = DateTime.fromFormat(date, "yyyy-MM-dd HH:mm:ss", { zone: "utc" });
   }
   if (!dt.isValid) return date;
-  return dt.toFormat("dd/MM/yy - h:mm:ss a");
+  return dt.setZone(timeZone).toFormat("dd/MM/yy - h:mm:ss a");
 }
 
 const axisStyle = { fill: "#fff", fontWeight: 600 };
@@ -64,7 +64,11 @@ const tooltipStyle = {
   color: "#fff",
 };
 
-export default function EquityChart({ operations, showDrawdown = true }) {
+export default function EquityChart({
+  operations,
+  showDrawdown = true,
+  timeZone = "UTC",
+}) {
   const data = buildEquityDrawdownData(operations);
   const [showEquity, setShowEquity] = useState(true);
   const [showDrawdownState, setShowDrawdown] = useState(true);
@@ -125,7 +129,7 @@ export default function EquityChart({ operations, showDrawdown = true }) {
             <CartesianGrid strokeDasharray="3 3" stroke="#444" />
             <XAxis
               dataKey="date"
-              tickFormatter={formatDateLuxon}
+              tickFormatter={(date) => formatDateLuxon(date, timeZone)}
               minTickGap={20}
               tick={axisStyle}
               axisLine={{ stroke: "#2de2e6" }}
@@ -182,7 +186,7 @@ export default function EquityChart({ operations, showDrawdown = true }) {
                   ? "Drawdown (%)"
                   : name,
               ]}
-              labelFormatter={(d) => `Date: ${formatDateLuxon(d)}`}
+              labelFormatter={(d) => `Date: ${formatDateLuxon(d, timeZone)}`}
               cursor={false}
             />
             <Legend

--- a/src/pages/Charts.jsx
+++ b/src/pages/Charts.jsx
@@ -46,7 +46,11 @@ export default function Charts() {
       </Typography>
 
       {/* 1. Gráfica Principal (Equity) */}
-      <EquityChart operations={closedTrades} showDrawdown={true} />
+      <EquityChart
+        operations={closedTrades}
+        showDrawdown={true}
+        timeZone={timeZone}
+      />
 
       {/* 2. Métricas Clave (2x2 grid) */}
       <Box

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -251,7 +251,11 @@ export default function Dashboard() {
         justifyContent="space-between"
       >
         <Grid sx={{ minWidth: "65%", maxWidth: "100%" }}>
-          <EquityChart operations={closedTrades} showDrawdown={false} />
+          <EquityChart
+            operations={closedTrades}
+            showDrawdown={false}
+            timeZone={timeZone}
+          />
         </Grid>
 
         <Grid


### PR DESCRIPTION
- Agregar parámetro timeZone a formatDateLuxon en EquityChart
- Actualizar EquityChart para aceptar y usar timeZone prop
- Corregir DrawdownChart con las mismas mejoras de timezone
- Actualizar páginas Dashboard y Charts para pasar timeZone
- Mantener compatibilidad hacia atrás con valor por defecto UTC