### PR TITLE
feat: unificar cálculo de winrates usando endpoint del backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
 ### 🎨 Enhanced
 
 ### 🔧 Technical
+
+### 📱 Mobile Features
+
+### 🖥️ Desktop Features
+
+## [v0.1.7] - 2025-10-04
+
+
+### ✨ Added
+
+### 🐛 Fixed
+
+### 🎨 Enhanced
+
+### 🔧 Technical
 - **Unificar cálculo de winrates usando endpoint del backend** - Charts page ahora usa `getStats()` para obtener winrates pre-calculados del backend en lugar de calcularlos localmente, eliminando duplicación de lógica y asegurando consistencia con Dashboard
 
 ### 📱 Mobile Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎨 Enhanced
 
 ### 🔧 Technical
+- **Unificar cálculo de winrates usando endpoint del backend** - Charts page ahora usa `getStats()` para obtener winrates pre-calculados del backend en lugar de calcularlos localmente, eliminando duplicación de lógica y asegurando consistencia con Dashboard
 
 ### 📱 Mobile Features
 

--- a/src/pages/Charts.jsx
+++ b/src/pages/Charts.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext } from "react";
 import { getOperations } from "../api/operations";
+import { getStats } from "../api/stats";
 import { Box, CircularProgress, Typography } from "@mui/material";
 import EquityChart from "../components/charts/EquityChart";
 import PnLHistogram from "../components/charts/PnLHistogram";
@@ -11,7 +12,6 @@ import MonthlyPerformanceChart from "../components/charts/MonthlyPerformanceChar
 import WeeklyMonthlyPerformanceChart from "../components/charts/WeeklyMonthlyPerformanceChart";
 import ScannerPerformanceChart from "../components/charts/ScannerPerformanceChart";
 import { TimeZoneContext } from "../contexts/AppContexts";
-import { calculateWinrates } from "../utils/formatting";
 
 export default function Charts() {
   const [closedTrades, setClosedTrades] = useState([]);
@@ -22,13 +22,17 @@ export default function Charts() {
   useEffect(() => {
     async function fetchOps() {
       setLoading(true);
-      const opsData = await getOperations();
+      // Obtener datos de ambos endpoints
+      const [opsData, statsData] = await Promise.all([
+        getOperations(),
+        getStats(),
+      ]);
+
       const closed = opsData?.closed || [];
       setClosedTrades(closed);
 
-      // Calcular winrates
-      const calculatedWinrates = calculateWinrates(closed);
-      setWinrates(calculatedWinrates);
+      // Usar winrates calculados en el backend (fuente única de verdad)
+      setWinrates(statsData?.winrates || null);
 
       setLoading(false);
     }


### PR DESCRIPTION
- Charts page ahora usa getStats() en lugar de calculateWinrates() local
- Elimina import innecesario de calculateWinrates
- Unifica fuente única de verdad para winrates (backend)
- Ambas páginas (Dashboard y Charts) ahora usan /api/stats
- Mejora consistencia y elimina código duplicado